### PR TITLE
handle accented characters etc

### DIFF
--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -47,7 +47,7 @@ module.exports = function (dir, opts={}) {
 
 	if (opts.dev) {
 		return function (req, res, next) {
-			let uri = req.path || req.pathname || parseurl(req).pathname;
+			let uri = decodeURIComponent(req.path || req.pathname || parseurl(req).pathname);
 			let arr = uri.includes('.') ? [uri] : toAssume(uri, extensions);
 			let file = arr.map(x => join(dir, x)).find(fs.existsSync);
 			if (!file) return next ? next() : notFound(res);
@@ -72,7 +72,7 @@ module.exports = function (dir, opts={}) {
 		};
 		cc && (headers['cache-control'] = cc);
 		opts.etag && (headers['etag'] = toEtag(stats));
-		FILES['/' + str.replace(/\\+/g, '/')] = { abs, stats, headers };
+		FILES['/' + encodeURIComponent(str.replace(/\\+/g, '/'))] = { abs, stats, headers };
 	});
 
 	return function (req, res, next) {


### PR DESCRIPTION
At present, a file like `public/fünke.txt` doesn't get served if you hit `/fünke`, because `req.path` is `/f%C3%BCnke`. This fixes it in both dev and prod mode.