### PR TITLE
Don't wipe scrollback history on start

### DIFF
--- a/packages/sirv-cli/boot.js
+++ b/packages/sirv-cli/boot.js
@@ -62,7 +62,7 @@ module.exports = function (dir, opts) {
 			if (err) throw err;
 			if (opts.quiet) return;
 
-			clear(true); // wipe screen, but don't wipe scrollback history
+			clear(true); // wipe screen, but not history
 			let { local, network } = access({ port, https });
 			stdout.write('\n' + PAD + colors.green('Your application is ready~! 🚀\n\n'));
 			isOther && stdout.write(PAD + colors.italic.dim(`➡ Port ${opts.port} is taken; using ${port} instead\n\n`));

--- a/packages/sirv-cli/boot.js
+++ b/packages/sirv-cli/boot.js
@@ -62,7 +62,7 @@ module.exports = function (dir, opts) {
 			if (err) throw err;
 			if (opts.quiet) return;
 
-			clear(); // wipe screen
+			clear(true); // wipe screen, but don't wipe scrollback history
 			let { local, network } = access({ port, https });
 			stdout.write('\n' + PAD + colors.green('Your application is ready~! 🚀\n\n'));
 			isOther && stdout.write(PAD + colors.italic.dim(`➡ Port ${opts.port} is taken; using ${port} instead\n\n`));


### PR DESCRIPTION
When using sirv together with some watching rebuilder like rollup (e.g. in svelte framework), sirv's wiping of the scrollback buffer makes it impossible to access build warnings.