### PR TITLE
pass an empty headers object on no match

### DIFF
--- a/packages/sirv-cli/boot.js
+++ b/packages/sirv-cli/boot.js
@@ -36,7 +36,7 @@ module.exports = function (dir, opts) {
 	}
 
 	if (opts.single) {
-		opts.onNoMatch = res => fn({ path:'/' }, res, r => (r.statusCode=404,r.end()));
+		opts.onNoMatch = res => fn({ path:'/', headers: {} }, res, r => (r.statusCode=404,r.end()));
 	}
 
 	fn = sirv(dir, opts);

--- a/packages/sirv-cli/boot.js
+++ b/packages/sirv-cli/boot.js
@@ -36,7 +36,7 @@ module.exports = function (dir, opts) {
 	}
 
 	if (opts.single) {
-		opts.onNoMatch = res => fn({ path:'/', headers: {} }, res, r => (r.statusCode=404,r.end()));
+		opts.onNoMatch = res => fn({ path:'/', headers:{} }, res, r => (r.statusCode=404,r.end()));
 	}
 
 	fn = sirv(dir, opts);


### PR DESCRIPTION
The `send()` function in `sirv` expects `req.headers` to be defined on the request when `dev` option is true causing the process to crash when running the fallback. 