### PR TITLE
sirv accepts mime option to allow mime checking to be overridden & extended

### DIFF
--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -71,6 +71,7 @@ function send(req, res, file, stats, headers={}) {
 
 module.exports = function (dir, opts={}) {
 	dir = resolve(dir || '.');
+	const mime2 = opts.mime || mime;
 
 	let isNotFound = opts.onNoMatch || is404;
 	let extensions = opts.extensions || ['html', 'htm'];
@@ -85,7 +86,7 @@ module.exports = function (dir, opts={}) {
 				if (stats.isDirectory()) continue;
 				setHeaders(res, uri, stats);
 				return send(req, res, file, stats, {
-					'Content-Type': mime.getType(file),
+					'Content-Type': mime2.getType(file),
 					'Last-Modified': stats.mtime.toUTCString(),
 					'Content-Length': stats.size,
 				});
@@ -104,7 +105,7 @@ module.exports = function (dir, opts={}) {
 
 		let headers = {
 			'Content-Length': stats.size,
-			'Content-Type': mime.getType(name),
+			'Content-Type': mime2.getType(name),
 			'Last-Modified': stats.mtime.toUTCString(),
 		};
 


### PR DESCRIPTION
I opted to dependency inject `mime` `opts.mime`.

Fix: https://github.com/lukeed/sirv/issues/38