### PR TITLE
Add support for ETag-based caching

### DIFF
--- a/packages/sirv-cli/boot.js
+++ b/packages/sirv-cli/boot.js
@@ -77,9 +77,15 @@ module.exports = function (dir, opts) {
 	}
 
 	opts.port = PORT || opts.port;
+<<<<<<< HEAD
 	toPort(opts.port).then(port => {
 		let hostname = HOST || opts.host || '0.0.0.0';
 		let https = opts.http2 || !!opts.ssl; // TODO
+=======
+	let hostname = HOST || opts.host || '0.0.0.0';
+	toPort({ host: hostname, port: opts.port }).then(port => {
+		let https = !!opts.ssl; // TODO
+>>>>>>> 01616eb... fix(sirv-cli): use `host` for port availability
 		let isOther = port != opts.port;
 		server.listen(port, hostname, err => {
 			if (err) throw err;

--- a/packages/sirv-cli/boot.js
+++ b/packages/sirv-cli/boot.js
@@ -77,15 +77,9 @@ module.exports = function (dir, opts) {
 	}
 
 	opts.port = PORT || opts.port;
-<<<<<<< HEAD
 	toPort(opts.port).then(port => {
 		let hostname = HOST || opts.host || '0.0.0.0';
 		let https = opts.http2 || !!opts.ssl; // TODO
-=======
-	let hostname = HOST || opts.host || '0.0.0.0';
-	toPort({ host: hostname, port: opts.port }).then(port => {
-		let https = !!opts.ssl; // TODO
->>>>>>> 01616eb... fix(sirv-cli): use `host` for port availability
 		let isOther = port != opts.port;
 		server.listen(port, hostname, err => {
 			if (err) throw err;

--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -135,6 +135,13 @@ module.exports = function (dir, opts={}) {
 		let data = fn(pathname, extns, dir, isEtag) || isSPA && fn(fallback, extns, dir, isEtag);
 		if (!data) return next ? next() : isNotFound(req, res);
 
+		const etag = opts.etag && req.headers['if-none-match'];
+		if (etag && etag === data.headers['ETag']) {
+			res.writeHead(304);
+			res.end();
+			return;
+		}
+
 		setHeaders(res, pathname, data.stats);
 		send(req, res, data.abs, data.stats, data.headers);
 	};

--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -135,11 +135,10 @@ module.exports = function (dir, opts={}) {
 		let data = fn(pathname, extns, dir, isEtag) || isSPA && fn(fallback, extns, dir, isEtag);
 		if (!data) return next ? next() : isNotFound(req, res);
 
-		const etag = opts.etag && req.headers['if-none-match'];
+		const etag = isEtag && req.headers['if-none-match'];
 		if (etag && etag === data.headers['ETag']) {
 			res.writeHead(304);
-			res.end();
-			return;
+			return res.end();
 		}
 
 		setHeaders(res, pathname, data.stats);


### PR DESCRIPTION
When providing an ETag header on responses, the client automatically sends that header value on subsequent requests for the matching resource as an `If-None-Match` request header. If the ETag value received in `If-None-Match` is the same as the ETag computed by the disk crawl, a 304 "Not Modified" status can be returned along with an empty body to indicate that the requestor's cached value should be used.


---

I'm currently using the following workaround to implement this manually:

```js
server.use((req, res, next) => {
	// `req` is not passed to setHeaders(), so we obtain that info here
	res._requestHeaders = req.headers;
	next();
});

server.use(
	sirv('public', {
		etag: true,
		setHeaders(res, path, stats) {
			const etag = res._requestHeaders['if-none-match'];
			const computedEtag = `W/"${stats.size}-${stats.mtime.getTime()}"`;
			if (etag && etag === computedEtag) {
				res.writeHead(304);
				res.end();
				// hack: disable sirv's normal response & piping:
				res.writeHead = res.write = res.end = () => {};
			}
		}
	})
);
```