### PR TITLE
Set content-encoding to 'br' instead of 'brotli'

### DIFF
--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -95,7 +95,7 @@ function toHeaders(name, stats, isEtag) {
 		'Last-Modified': stats.mtime.toUTCString(),
 	};
 	if (isEtag) headers['ETag'] = `W/"${stats.size}-${stats.mtime.getTime()}"`;
-	if (/\.br$/.test(name)) isEncoding(name, 'brotli', headers);
+	if (/\.br$/.test(name)) isEncoding(name, 'br', headers);
 	if (/\.gz$/.test(name)) isEncoding(name, 'gzip', headers);
 	return headers;
 }


### PR DESCRIPTION
When started with `--brotli` option and pre-compressed files exist the server responds with the wrong value for content encoding header - namely `brotli` - instead of the [proper `br`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding) one.