### PR TITLE
sirv-cli HTTP1 backward compatibility

### DIFF
--- a/packages/sirv-cli/index.js
+++ b/packages/sirv-cli/index.js
@@ -58,7 +58,7 @@ module.exports = function (dir, opts) {
 		opts.cert = readFileSync(opts.cert);
 		if (opts.cacert) opts.cacert = readFileSync(opts.cacert);
 		if (opts.pass) opts.passphrase = opts.pass;
-		if (opts.allowHTTP1 === undefined) opts.allowHTTP1 = true;
+		opts.allowHTTP1 = true;
 
 		server = require('http2').createSecureServer(opts, fn);
 	} else {

--- a/packages/sirv-cli/index.js
+++ b/packages/sirv-cli/index.js
@@ -58,6 +58,7 @@ module.exports = function (dir, opts) {
 		opts.cert = readFileSync(opts.cert);
 		if (opts.cacert) opts.cacert = readFileSync(opts.cacert);
 		if (opts.pass) opts.passphrase = opts.pass;
+		if (opts.allowHTTP1 === undefined) opts.allowHTTP1 = true;
 
 		server = require('http2').createSecureServer(opts, fn);
 	} else {

--- a/packages/sirv-cli/index.js
+++ b/packages/sirv-cli/index.js
@@ -54,11 +54,11 @@ module.exports = function (dir, opts) {
 			return exit('HTTP/2 requires "key" and "cert" values');
 		}
 
+		opts.allowHTTP1 = true; // grace
 		opts.key = readFileSync(opts.key);
 		opts.cert = readFileSync(opts.cert);
 		if (opts.cacert) opts.cacert = readFileSync(opts.cacert);
 		if (opts.pass) opts.passphrase = opts.pass;
-		opts.allowHTTP1 = true;
 
 		server = require('http2').createSecureServer(opts, fn);
 	} else {

--- a/tests/sirv-cli.js
+++ b/tests/sirv-cli.js
@@ -154,7 +154,7 @@ http2('should have backward compatibility with HTTP/1', async () => {
 	let key = await utils.write('foobar.key2', pems.private);
 	let cert = await utils.write('foobar.cert2', pems.cert);
 
-	let server = await utils.spawn('--http2', '--key', key, '--cert', cert);
+	let server = await utils.spawn('--http2', '--key', key, '--cert', cert, '--port', '5001');
 
 	try {
 		let res = await server.send('GET', '/blog', { rejectUnauthorized: false });

--- a/tests/sirv-cli.js
+++ b/tests/sirv-cli.js
@@ -154,7 +154,7 @@ http2('should have backward compatibility with HTTP/1', async () => {
 	let key = await utils.write('foobar.key2', pems.private);
 	let cert = await utils.write('foobar.cert2', pems.cert);
 
-	let server = await utils.spawn('--http2', '--key', key, '--cert', cert, '--port', '5001');
+	let server = await utils.spawn('--http2', '--key', key, '--cert', cert);
 
 	try {
 		let res = await server.send('GET', '/blog', { rejectUnauthorized: false });

--- a/tests/sirv-cli.js
+++ b/tests/sirv-cli.js
@@ -149,4 +149,19 @@ http2('should start a HTTP/2 server with valid args', async () => {
 	}
 });
 
+http2('should have backward compatibility with HTTP/1', async () => {
+	let pems = selfsigned.generate();
+	let key = await utils.write('foobar.key2', pems.private);
+	let cert = await utils.write('foobar.cert2', pems.cert);
+
+	let server = await utils.spawn('--http2', '--key', key, '--cert', cert);
+
+	try {
+		let res = await server.send('GET', '/blog', { rejectUnauthorized: false });
+		await utils.matches(res, 200, 'blog.html', 'utf8');
+	} finally {
+		server.close();
+	}
+});
+
 http2.run();


### PR DESCRIPTION
`sirv --http2 [cert/key]` servers will now allow HTTP/1 connections. This is to allow https://... requests over HTTP/1.

Supercedes #73.