### PR TITLE
fix(sirv): a request with range headers appends Content-Length, Conte…

### DIFF
--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -55,8 +55,10 @@ function is404(req, res) {
 	return (res.statusCode=404,res.end());
 }
 
-function send(req, res, file, stats, headers={}) {
+function send(req, res, file, stats, baseHeaders={}) {
 	let code=200, tmp, opts={}
+
+	let headers = Object.assign({}, baseHeaders);
 
 	if (tmp = res.getHeader('content-type')) {
 		headers['Content-Type'] = tmp;

--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -55,13 +55,11 @@ function is404(req, res) {
 	return (res.statusCode=404,res.end());
 }
 
-function send(req, res, file, stats, baseHeaders={}) {
+function send(req, res, file, stats, headers={}) {
 	let code=200, tmp, opts={}
 
-	let headers = Object.assign({}, baseHeaders);
-
 	if (tmp = res.getHeader('content-type')) {
-		headers['Content-Type'] = tmp;
+		headers = { ...headers, 'Content-Type': tmp };
 	}
 
 	if (req.headers.range) {
@@ -75,7 +73,8 @@ function send(req, res, file, stats, baseHeaders={}) {
 			res.statusCode = 416;
 			return res.end();
 		}
-
+		
+		if (!tmp) headers = { ...headers };
 		headers['Content-Range'] = `bytes ${start}-${end}/${stats.size}`;
 		headers['Content-Length'] = (end - start + 1);
 		headers['Accept-Ranges'] = 'bytes';

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -987,7 +987,6 @@ ranges('should not mutate response headers on subsequent non-Range requests :: d
 
 		let headers = { Range: 'bytes=0-10' };
 		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
-		assert.is(res1.statusCode, 200);
 		assert.is(res1.headers['content-length'], `${file.size}`);
 		assert.ok(res1.headers['content-range']);
 		assert.ok(res1.headers['accept-ranges']);
@@ -1011,7 +1010,6 @@ ranges('should not mutate response headers on subsequent non-Range requests :: p
 
 		let headers = { Range: 'bytes=0-10' };
 		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
-		assert.is(res1.statusCode, 200);
 		assert.is(res1.headers['content-length'], `${file.size}`);
 		assert.ok(res1.headers['content-range']);
 		assert.ok(res1.headers['accept-ranges']);

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -979,7 +979,31 @@ ranges('should throw `416` when range cannot be met (overflow)', async () => {
 	}
 });
 
-ranges('should not mutate response headers on subsequent non range requests :: prod', async () => {
+ranges('should not mutate response headers on subsequent non-Range requests :: dev', async () => {
+	let server = utils.http({ dev: true });
+
+	try {
+		let file = await utils.lookup('bundle.67329.js', 'utf8');
+
+		let headers = { Range: 'bytes=0-10' };
+		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
+		assert.is(res1.statusCode, 200);
+		assert.is(res1.headers['content-length'], `${file.size}`);
+		assert.ok(res1.headers['content-range']);
+		assert.ok(res1.headers['accept-ranges']);
+
+		let res2 = await server.send('GET', '/bundle.67329.js');
+		assert.is(res2.statusCode, 200);
+		assert.is(res2.headers['content-length'], `${file.size}`);
+		assert.not(res2.headers['content-range']);
+		assert.not(res2.headers['accept-ranges']);
+
+	} finally {
+		server.close();
+	}
+});
+
+ranges('should not mutate response headers on subsequent non-Range requests :: prod', async () => {
 	let server = utils.http({ dev: false });
 
 	try {
@@ -987,6 +1011,10 @@ ranges('should not mutate response headers on subsequent non range requests :: p
 
 		let headers = { Range: 'bytes=0-10' };
 		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
+		assert.is(res1.statusCode, 200);
+		assert.is(res1.headers['content-length'], `${file.size}`);
+		assert.ok(res1.headers['content-range']);
+		assert.ok(res1.headers['accept-ranges']);
 
 		let res2 = await server.send('GET', '/bundle.67329.js');
 		assert.is(res2.statusCode, 200);

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -985,15 +985,10 @@ ranges('should not mutate response headers on subsequent non range requests :: p
 	try {
 		let file = await utils.lookup('bundle.67329.js', 'utf8');
 
-
 		let headers = { Range: 'bytes=0-10' };
 		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
-		assert.is(res1.statusCode, 206);
-		assert.is(res1.headers['content-length'], '11');
-		assert.is(res1.headers['accept-ranges'], 'bytes');
-		assert.is(res1.headers['content-range'], `bytes 0-10/${file.size}`);
 
-		let res2 = await server.send('GET', '/bundle.67329.js', {});
+		let res2 = await server.send('GET', '/bundle.67329.js');
 		assert.is(res2.statusCode, 200);
 		assert.is(res2.headers['content-length'], `${file.size}`);
 		assert.not(res2.headers['content-range']);

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -987,7 +987,6 @@ ranges('should not mutate response headers on subsequent non-Range requests :: d
 
 		let headers = { Range: 'bytes=0-10' };
 		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
-		assert.is(res1.headers['content-length'], `${file.size}`);
 		assert.ok(res1.headers['content-range']);
 		assert.ok(res1.headers['accept-ranges']);
 
@@ -1010,7 +1009,6 @@ ranges('should not mutate response headers on subsequent non-Range requests :: p
 
 		let headers = { Range: 'bytes=0-10' };
 		let res1 = await server.send('GET', '/bundle.67329.js', { headers });
-		assert.is(res1.headers['content-length'], `${file.size}`);
 		assert.ok(res1.headers['content-range']);
 		assert.ok(res1.headers['accept-ranges']);
 


### PR DESCRIPTION
A request with Range headers present will result in the headers object being modified for all subsequent requests.

To reproduce:

```
curl -X GET  http://localhost:5000/pnggrad16rgb.png  -H 'Cache-Control: no-cache'

{
  'Content-Length': 3974,
  'Content-Type': 'image/png',
  'Last-Modified': 'Fri, 31 Jul 2020 04:30:09 GMT'
}
```

```
curl -X GET http://localhost:5000/pnggrad16rgb.png -H 'Cache-Control: no-cache' -H 'Range: bytes=0-499'

{
  'Content-Length': 500,
  'Content-Type': 'image/png',
  'Last-Modified': 'Fri, 31 Jul 2020 04:30:09 GMT',
  'Content-Range': 'bytes 0-499/3974',
  'Accept-Ranges': 'bytes'
}
```

```
curl -X GET  http://localhost:5000/pnggrad16rgb.png  -H 'Cache-Control: no-cache'

{
  'Content-Length': 500,
  'Content-Type': 'image/png',
  'Last-Modified': 'Fri, 31 Jul 2020 04:30:09 GMT',
  'Content-Range': 'bytes 0-499/3974',
  'Accept-Ranges': 'bytes'
}
```

Image used for above test:

![pnggrad16rgb](https://user-images.githubusercontent.com/57962793/89002183-bb0cef00-d2fc-11ea-9fa2-e3addcab20ef.png)
