### PR TITLE
Fix ignore of requests with extensions

### DIFF
--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -127,7 +127,7 @@ export default function (dir, opts={}) {
 
 	let ignores = [];
 	if (opts.ignores !== false) {
-		ignores.push(/\/\w+\.\w+$/); // any extn
+		ignores.push(/[/]([A-Za-z\s\d~$._-]+\.\w+){1,}$/); // any extn
 		if (opts.dotfiles) ignores.push(/\/\.\w/);
 		else ignores.push(/\/\.well-known/);
 		[].concat(opts.ignores || []).forEach(x => {

--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -127,7 +127,7 @@ export default function (dir, opts={}) {
 
 	let ignores = [];
 	if (opts.ignores !== false) {
-		ignores.push(/\/\w\.\w+$/); // any extn
+		ignores.push(/\/\w+\.\w+$/); // any extn
 		if (opts.dotfiles) ignores.push(/\/\.\w/);
 		else ignores.push(/\/\.well-known/);
 		[].concat(opts.ignores || []).forEach(x => {

--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -127,7 +127,7 @@ export default function (dir, opts={}) {
 
 	let ignores = [];
 	if (opts.ignores !== false) {
-		ignores.push(/\w\.\w+$/); // any extn
+		ignores.push(/\/\w\.\w+$/); // any extn
 		if (opts.dotfiles) ignores.push(/\/\.\w/);
 		else ignores.push(/\/\.well-known/);
 		[].concat(opts.ignores || []).forEach(x => {


### PR DESCRIPTION
Before this change: If a URL happens to contain a `.` but it's not a request to a file, it'll be ignored (a 404 is returned). E.g. http://localhost:5000/51.89768130456134,-8.470441788798238. 

The regex now only matches if the path contains valid filename characters all the way from the slash til the end, not just at the end.