### PR TITLE
Add option "mimeOverride" so you can override MIME/Content-Type headers

### DIFF
--- a/packages/sirv/sirv.d.ts
+++ b/packages/sirv/sirv.d.ts
@@ -17,6 +17,7 @@ declare module 'sirv' {
 		dotfiles?: boolean;
 		brotli?: boolean;
 		gzip?: boolean;
+		mimeOverride?: { [key: string]: string },
 		onNoMatch?: (req: IncomingMessage, res: ServerResponse) => void;
 		setHeaders?: (res: ServerResponse, pathname: string, stats: Stats) => void;
 	}


### PR DESCRIPTION
The use-case for this is bundlers like Vite, that serve compiled
TypeScript with a .ts file extension. The MIME standard has assigned
content video/mp2t to the .ts extension, but in the case of bundlers,
they would need to serve these files with "Content-Type: application/javascript".

Here is the specific use case: https://github.com/vitejs/vite/issues/2642