### PR TITLE
Fix precedence of command line arguments

### DIFF
--- a/packages/sirv-cli/index.js
+++ b/packages/sirv-cli/index.js
@@ -78,8 +78,8 @@ module.exports = function (dir, opts) {
 		});
 	}
 
-	opts.port = PORT || opts.port;
-	let hostname = HOST || opts.host || '0.0.0.0';
+	opts.port = opts.port || PORT;
+	let hostname = opts.host || HOST || '0.0.0.0';
 	toPort({ host: hostname, port: opts.port }).then(port => {
 		let isOther = port != opts.port;
 		let https = opts.http2 || !!opts.ssl; // TODO


### PR DESCRIPTION
Fix for issue #104

Swap opts.port and env.PORT precedence, when defining what port should be set as
Swap opts.host and env.HOST precedence, when defining what hostname should be set as