### PR TITLE
feat: support NO_COLOR by updating kleur

### DIFF
--- a/packages/sirv-cli/package.json
+++ b/packages/sirv-cli/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "console-clear": "^1.1.0",
     "get-port": "^3.2.0",
-    "kleur": "^3.0.0",
+    "kleur": "^4.1.4",
     "local-access": "^1.0.1",
     "sade": "^1.6.0",
     "semiver": "^1.0.0",


### PR DESCRIPTION
Some terminals do not support colors and will output a bunch of
unnecessary clutter instead. kleur as of v4.1.0 support NO_COLOR 
var which disables color completely