### PR TITLE
fix(sirv): skip `req._decode` shortcuts; decode manually

### DIFF
--- a/packages/sirv/package.json
+++ b/packages/sirv/package.json
@@ -20,7 +20,7 @@
     "node": ">= 10"
   },
   "dependencies": {
-    "@polka/url": "^1.0.0-next.19",
+    "@polka/url": "^1.0.0-next.20",
     "mime": "^2.3.1",
     "totalist": "^1.0.0"
   }


### PR DESCRIPTION
With https://github.com/lukeed/polka/pull/175, there's no longer a `toDecode` parameter, so `sirv` must do it manually.

Also, through https://github.com/vitejs/vite/pull/4728 discussion, relying on existing `req.path` or `req._decoded` mutations could cause issues downstream, depending on how (or how often) `sirv` was invoked. To deal with this, `sirv` invokes `@polka/url` every request for consistency, which is fine because the parser is so fast.