### PR TITLE
fix: append charset=utf-8 to text/html

### DIFF
--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -88,16 +88,26 @@ function send(req, res, file, stats, headers) {
 	fs.createReadStream(file, opts).pipe(res);
 }
 
+const ENCODING = {
+	'.br': 'br',
+	'.gz': 'gzip',
+};
+
 function toHeaders(name, stats, isEtag) {
-	let enc = {'.br':'br','.gz':'gzip'}[name.slice(-3)]
-	let type = mime.getType(name.slice(0, enc && -3)) || ''
+	let enc = ENCODING[name.slice(-3)];
+
+	let ctype = mime.getType(name.slice(0, enc && -3)) || '';
+	if (ctype === 'text/html') ctype += ';charset=utf-8';
+
 	let headers = {
 		'Content-Length': stats.size,
-		'Content-Type': type + (type == 'text/html' ? '; charset=utf-8' : ''),
+		'Content-Type': ctype,
 		'Last-Modified': stats.mtime.toUTCString(),
 	};
+
 	if (enc) headers['Content-Encoding'] = enc;
 	if (isEtag) headers['ETag'] = `W/"${stats.size}-${stats.mtime.getTime()}"`;
+
 	return headers;
 }
 

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -78,7 +78,7 @@ export async function lookup(filepath, enc) {
 	filedata = await readfile(full, enc);
 
 	let ctype = mime.getType(full) || '';
-	if (ctype === 'text/html') ctype += '; charset=utf-8';
+	if (ctype === 'text/html') ctype += ';charset=utf-8';
 
 	return CACHE[filepath] = {
 		data: filedata,

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -733,7 +733,7 @@ brotli('should serve prepared `.br` file of any asset, if found', async () => {
 
 	try {
 		let res1 = await server.send('GET', '/', { headers });
-		assert.is(res1.headers['content-type'], 'text/html; charset=utf-8');
+		assert.is(res1.headers['content-type'], 'text/html;charset=utf-8');
 		assert.is(res1.headers['content-encoding'], 'br');
 		assert.is(res1.data, 'brotli html\n');
 		assert.is(res1.statusCode, 200);
@@ -751,7 +751,7 @@ brotli('should be preferred when "Accept-Encoding" allows both', async () => {
 
 	try {
 		let res1 = await server.send('GET', '/', { headers });
-		assert.is(res1.headers['content-type'], 'text/html; charset=utf-8');
+		assert.is(res1.headers['content-type'], 'text/html;charset=utf-8');
 		assert.is(res1.headers['content-encoding'], 'br');
 		assert.is(res1.data, 'brotli html\n');
 		assert.is(res1.statusCode, 200);
@@ -798,7 +798,7 @@ gzip('should serve prepared `.gz` file of any asset, if found', async () => {
 
 	try {
 		let res1 = await server.send('GET', '/', { headers });
-		assert.is(res1.headers['content-type'], 'text/html; charset=utf-8');
+		assert.is(res1.headers['content-type'], 'text/html;charset=utf-8');
 		assert.is(res1.headers['content-encoding'], 'gzip');
 		assert.is(res1.data, 'gzip html\n');
 		assert.is(res1.statusCode, 200);
@@ -816,7 +816,7 @@ gzip('should defer to brotli when "Accept-Encoding" allows both', async () => {
 
 	try {
 		let res1 = await server.send('GET', '/', { headers });
-		assert.is(res1.headers['content-type'], 'text/html; charset=utf-8');
+		assert.is(res1.headers['content-type'], 'text/html;charset=utf-8');
 		assert.is(res1.headers['content-encoding'], 'br');
 		assert.is(res1.data, 'brotli html\n');
 		assert.is(res1.statusCode, 200);


### PR DESCRIPTION
Closes #106

I considered fixing this upstream in "mime" or "mime-db" packages, but then I came across these issues, which indicated that it's not a viable path.

https://github.com/broofa/mime/issues/174
https://github.com/jshttp/mime-db/issues/94

**Size before:** 5204 bytes
**Size after:** 5108 bytes (-96)