### PR TITLE
Allow CORP Headers, Enabling SharedArrayBuffer

### DIFF
--- a/packages/sirv-cli/bin.js
+++ b/packages/sirv-cli/bin.js
@@ -16,6 +16,7 @@ sade('sirv [dir]')
 	.option('-e, --etag', 'Enable "ETag" header')
 	.option('-d, --dotfiles', 'Enable dotfile asset requests')
 	.option('-c, --cors', 'Enable "CORS" headers to allow any origin requestor')
+	.option('-CP --corp', 'Enable "CORP" headers, set to same-orgin')
 	.option('-G, --gzip', 'Send precompiled "*.gz" files when "gzip" is supported', true)
 	.option('-B, --brotli', 'Send precompiled "*.br" files when "brotli" is supported', true)
 	.option('-m, --maxage', 'Enable "Cache-Control" header & define its "max-age" value (sec)')
@@ -39,6 +40,7 @@ sade('sirv [dir]')
 			immutable: false,
 			http2: false,
 			cors: false,
+			corp: false,
 			logs: true,
 		}
 	});

--- a/packages/sirv-cli/index.js
+++ b/packages/sirv-cli/index.js
@@ -34,10 +34,14 @@ module.exports = function (dir, opts) {
 	dir = resolve(dir || '.');
 	opts.maxAge = opts.m;
 
-	if (opts.cors) {
-		opts.setHeaders = res => {
+	opts.setHeaders = res => {
+		if (opts.cors) {
 			res.setHeader('Access-Control-Allow-Origin', '*');
 			res.setHeader('Access-Control-Allow-Headers', 'Origin, Content-Type, Accept, Range');
+		}
+		if (opts.corp) {
+			res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+			res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
 		}
 	}
 


### PR DESCRIPTION
I've updated the sirv-cli to allow for setting both [Cross-Origin-Embedder-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Embedder-Policy), and [Cross-Origin-Opener-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cross-Origin-Opener-Policy) so that you can use [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) in modern browser versions.

Explaining the need: [Blog Regarding SharedArrayBuffer](https://blog.logrocket.com/understanding-sharedarraybuffer-and-cross-origin-isolation/#:~:text=What%20is%20cross%2Dorigin%20isolation%3F)

Necessity/Purpose: So that you can work locally with [@ffmpeg/ffmpeg](https://github.com/ffmpegwasm/ffmpeg.wasm) which relies on SharedArrayBuffer