### PR TITLE
Apply publint recommendations

### DIFF
--- a/packages/sirv/package.json
+++ b/packages/sirv/package.json
@@ -3,9 +3,13 @@
   "version": "2.0.2",
   "description": "The optimized & lightweight middleware for serving requests to static assets",
   "repository": "lukeed/sirv",
-  "module": "build.mjs",
-  "types": "sirv.d.ts",
-  "main": "build.js",
+  "exports": {
+    ".": {
+      "types": "./sirv.d.ts",
+      "import": "./build.mjs",
+      "require": "./build.js"
+    }
+  },
   "license": "MIT",
   "files": [
     "build.*",


### PR DESCRIPTION
Adds a `pkg.exports` field. Today, if you import `sirv` in a `"type": "module"` app, it will import `build.js` rather than `build.mjs`. With this change, `build.mjs` is imported. Not that it actually makes a difference.