### PR TITLE
fix: should not set "Content-Encoding" for a direct request of a compressed file

### DIFF
--- a/tests/public/test.csv
+++ b/tests/public/test.csv
@@ -1,0 +1,1 @@
+test.csv

--- a/tests/public/test.csv.gz
+++ b/tests/public/test.csv.gz
@@ -1,0 +1,1 @@
+test.csv.gz

--- a/tests/public/test.csv.gz.gz
+++ b/tests/public/test.csv.gz.gz
@@ -1,0 +1,1 @@
+test.csv.gz.gz

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -868,8 +868,7 @@ gzip('should not set "Content-Encoding" for a direct request of a copressed file
 	}
 });
 
-// TODO
-gzip.skip('should not set "Content-Encoding" for a direct request of a copressed file (dev: false)', async () => {
+gzip('should not set "Content-Encoding" for a direct request of a copressed file (dev: false)', async () => {
 	let server = utils.http({ dev: false, gzip: true });
 	try {
 		await testGzipDirectRequest(server);

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -859,6 +859,27 @@ gzip('should defer to brotli when "Accept-Encoding" allows both', async () => {
 	}
 });
 
+// TODO: handle also { dev: false }
+gzip('should not set "Content-Encoding" for a direct request of a copressed file', async () => {
+	let server = utils.http({ dev: true });
+
+	try {
+		let res1 = await server.send('GET', '/data.js.gz', { headers: { 'Accept-Encoding': 'gzip' } });
+		assert.is(res1.headers['content-type'], 'application/gzip');
+		assert.is(res1.headers['content-encoding'], undefined);
+		assert.is(res1.data, 'gzip js file\n');
+		assert.is(res1.statusCode, 200);
+
+		let res2 = await server.send('GET', '/data.js.gz');
+		assert.is(res2.headers['content-type'], 'application/gzip');
+		assert.is(res2.headers['content-encoding'], undefined);
+		assert.is(res2.data, 'gzip js file\n');
+		assert.is(res2.statusCode, 200);
+	} finally {
+		server.close();
+	}
+});
+
 gzip.run();
 
 // ---

--- a/tests/sirv.js
+++ b/tests/sirv.js
@@ -859,26 +859,76 @@ gzip('should defer to brotli when "Accept-Encoding" allows both', async () => {
 	}
 });
 
-// TODO: handle also { dev: false }
-gzip('should not set "Content-Encoding" for a direct request of a copressed file', async () => {
-	let server = utils.http({ dev: true });
-
+gzip('should not set "Content-Encoding" for a direct request of a copressed file (dev: true)', async () => {
+	let server = utils.http({ dev: true, gzip: true });
 	try {
-		let res1 = await server.send('GET', '/data.js.gz', { headers: { 'Accept-Encoding': 'gzip' } });
-		assert.is(res1.headers['content-type'], 'application/gzip');
-		assert.is(res1.headers['content-encoding'], undefined);
-		assert.is(res1.data, 'gzip js file\n');
-		assert.is(res1.statusCode, 200);
-
-		let res2 = await server.send('GET', '/data.js.gz');
-		assert.is(res2.headers['content-type'], 'application/gzip');
-		assert.is(res2.headers['content-encoding'], undefined);
-		assert.is(res2.data, 'gzip js file\n');
-		assert.is(res2.statusCode, 200);
+		await testGzipDirectRequest(server);
 	} finally {
 		server.close();
 	}
 });
+
+// TODO
+gzip.skip('should not set "Content-Encoding" for a direct request of a copressed file (dev: false)', async () => {
+	let server = utils.http({ dev: false, gzip: true });
+	try {
+		await testGzipDirectRequest(server);
+	} finally {
+		server.close();
+	}
+});
+
+async function testGzipDirectRequest(server) {
+	let headers = { 'Accept-Encoding': 'gzip' };
+
+	{
+		let res = await server.send('GET', '/test.csv.gz.gz', { headers });
+		assert.is(res.headers['content-type'], 'application/gzip');
+		assert.is(res.headers['content-encoding'], undefined);
+		assert.is(res.data, 'test.csv.gz.gz\n');
+		assert.is(res.statusCode, 200);
+	}
+
+	{
+		let res = await server.send('GET', '/test.csv.gz', { headers });
+		assert.is(res.headers['content-type'], 'application/gzip');
+		assert.is(res.headers['content-encoding'], 'gzip');
+		assert.is(res.data, 'test.csv.gz.gz\n');
+		assert.is(res.statusCode, 200);
+	}
+
+	{
+		let res = await server.send('GET', '/test.csv', { headers });
+		assert.is(res.headers['content-type'], 'text/csv');
+		assert.is(res.headers['content-encoding'], 'gzip');
+		assert.is(res.data, 'test.csv.gz\n');
+		assert.is(res.statusCode, 200);
+	}
+
+	{
+		let res = await server.send('GET', '/test.csv.gz.gz');
+		assert.is(res.headers['content-type'], 'application/gzip');
+		assert.is(res.headers['content-encoding'], undefined);
+		assert.is(res.data, 'test.csv.gz.gz\n');
+		assert.is(res.statusCode, 200);
+	}
+
+	{
+		let res = await server.send('GET', '/test.csv.gz');
+		assert.is(res.headers['content-type'], 'application/gzip');
+		assert.is(res.headers['content-encoding'], undefined);
+		assert.is(res.data, 'test.csv.gz\n');
+		assert.is(res.statusCode, 200);
+	}
+
+	{
+		let res = await server.send('GET', '/test.csv');
+		assert.is(res.headers['content-type'], 'text/csv');
+		assert.is(res.headers['content-encoding'], undefined);
+		assert.is(res.data, 'test.csv\n');
+		assert.is(res.statusCode, 200);
+	}
+}
 
 gzip.run();
 


### PR DESCRIPTION
- closes https://github.com/lukeed/sirv/issues/158

`Content-Encoding` should be used only when sirv is serving pre-compressed files (e.g. test.csv -> test.csv.gz), but it should be avoided when users are requesting a compressed file directly (e.g. test.csv.gz).

Citing it from https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Encoding
 
>  If the original media is encoded in some way (e.g. a zip file) then this information would not be included in the Content-Encoding header.

The summary of change is:
- replace `extns: string` with `extns: { ext: string, encoded: boolean }[]`,
- when matching a file with `viaLocal` or `viaCache`, it also returns `{ name: string, encoded: boolean }` 
- move `Content-Type` and `Content-Encoding` handling from `toHeaders` to `send` since it now requires `name` and `encoded` to decide these two headers.