### PR TITLE
add `node:` prefix for Deno compatibility

### DIFF
--- a/packages/sirv-cli/index.js
+++ b/packages/sirv-cli/index.js
@@ -1,8 +1,8 @@
 const sirv = require('sirv');
 const colors = require('kleur');
 const semiver = require('semiver');
-const { resolve } = require('path');
-const { readFileSync } = require('fs');
+const { resolve } = require('node:path');
+const { readFileSync } = require('node:fs');
 const laccess = require('local-access');
 const clear = require('console-clear');
 const tinydate = require('tinydate');

--- a/packages/sirv/index.js
+++ b/packages/sirv/index.js
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import { join, normalize, resolve } from 'path';
+import * as fs from 'node:fs';
+import { join, normalize, resolve } from 'node:path';
 import { totalist } from 'totalist/sync';
 import { parse } from '@polka/url';
 import { lookup } from 'mrmime';


### PR DESCRIPTION
This PR adds the `node:` prefix to Node's modules for compatibility with Deno.