### PR TITLE
Implement new option root that denotes the URI prefix

### DIFF
--- a/packages/sirv/index.d.mts
+++ b/packages/sirv/index.d.mts
@@ -14,6 +14,7 @@ export type RequestHandler = (
 export interface Options {
 	dev?: boolean;
 	etag?: boolean;
+	root?: string;
 	maxAge?: number;
 	immutable?: boolean;
 	single?: string | boolean;

--- a/packages/sirv/index.d.ts
+++ b/packages/sirv/index.d.ts
@@ -15,6 +15,7 @@ declare namespace sirv {
 	export interface Options {
 		dev?: boolean;
 		etag?: boolean;
+		root?: string;
 		maxAge?: number;
 		immutable?: boolean;
 		single?: string | boolean;

--- a/packages/sirv/readme.md
+++ b/packages/sirv/readme.md
@@ -66,6 +66,25 @@ Additionally, `dev` mode will ignore `maxAge` and `immutable` as these options g
 
 > **Important:** Do not use `dev` mode in production!
 
+#### opts.root
+Type: `String`<br>
+Default: `/`
+
+Denote the used URI prefix that the given resources will be served to. By default, every resource will be served at the root (`/`).
+
+This option will always ensure at least one leading and trailing slash, meaning that
+`directory`, `/directory` and `directory/` will all be completed to `/directory/`.
+
+For example, using some arbitrary web server:
+```js
+// Will serve `./static/js/common.js` as `/js/common.js`
+app.use(Sirv('./static/'))
+
+// Will serve `./static/js/common.js` as `/my-directory/js/common.js`
+app.use(Sirv('./static/', { root: '/my-directory/' }))
+```
+
+
 #### opts.etag
 Type: `Boolean`<br>
 Default: `false`

--- a/tests/sirv.mjs
+++ b/tests/sirv.mjs
@@ -609,6 +609,48 @@ dotfiles.run();
 
 // ---
 
+const root = suite('root');
+root('should serve at the given root option', async () => {
+	let server = utils.http({ root: '/application/' });
+
+	try {
+		await server.send('GET', '/sw.js').catch(err => {
+			assert.is(err.statusCode, 404);
+		});
+
+		let res = await server.send('GET', '/application/sw.js');
+		assert.is(res.headers['content-type'], 'text/javascript');
+		assert.is(res.statusCode, 200);
+	} finally {
+		server.close();
+	}
+});
+root('should serve directories at the given root option', async () => {
+	let server = utils.http({ root: '/application/' });
+
+	try {
+		let res = await server.send('GET', '/application/contact/index.html');
+		assert.is(res.statusCode, 200);
+	} finally {
+		server.close();
+	}
+});
+root('should ensure leading and trailing slash on root option', async () => {
+	let server = utils.http({ root: 'application' });
+
+	try {
+		let res = await server.send('GET', '/application/sw.js');
+		assert.is(res.headers['content-type'], 'text/javascript');
+		assert.is(res.statusCode, 200);
+	} finally {
+		server.close();
+	}
+});
+
+root.run();
+
+// ---
+
 const dev = suite('dev');
 
 dev('should not rely on initial Cache fill', async () => {


### PR DESCRIPTION
Hi!

Here's a very simple addition of a new option `root` that allows for serving static files at a different URI prefix.
Example:
```js
// Serve `./static/js/common.js` as `/js/common.js` (default behavior)
app.use(Sirv('./static/'))

// Serve `./static/js/common.js` as `/my-directory/js/common.js`
app.use(Sirv('./static/', {
  root: '/my-directory/'
}))
```

I wrote some tests for the new option and all other tests pass as well. Nevertheless you should probably look over it yourself to see if my approach is sound! `sirv-cli` was left untouched.

This closes https://github.com/lukeed/sirv/issues/148.